### PR TITLE
Allow overriding chrome flags on launch

### DIFF
--- a/src/usus.js
+++ b/src/usus.js
@@ -18,12 +18,12 @@ import type {
 
 const debug = createDebug('usus');
 
-export const launchChrome = () => {
+export const launchChrome = (flags: string[] = [
+  '--disable-gpu',
+  '--headless'
+]) => {
   return launch({
-    chromeFlags: [
-      '--disable-gpu',
-      '--headless'
-    ]
+    chromeFlags: flags
   });
 };
 

--- a/src/usus.js
+++ b/src/usus.js
@@ -18,13 +18,13 @@ import type {
 
 const debug = createDebug('usus');
 
-export const launchChrome = (flags: string[] = [
-  '--disable-gpu',
-  '--headless'
-]) => {
-  return launch({
-    chromeFlags: flags
-  });
+export const launchChrome = (options: {chromeFlags: string[]} = {
+  chromeFlags: [
+    '--disable-gpu',
+    '--headless'
+  ]
+}) => {
+  return launch(options);
 };
 
 const inlineStyles = async (DOM: *, Runtime: *, rootNodeId: number, styles: string) => {


### PR DESCRIPTION
Sometimes it could be helpful to avoid issues running usus in docker (e.g. to pass additional flag `--no-sandbox` or others).