### PR TITLE
Replacing relative paths with absolute ones in generated critical CSS

### DIFF
--- a/src/usus.js
+++ b/src/usus.js
@@ -305,7 +305,7 @@ export const render = async (url: string, userConfiguration: UserConfigurationTy
         let rule = stylesheet.text.slice(usedRule.startOffset, usedRule.endOffset);
         const cssFileUrl = addedStyleSheets[usedRule.styleSheetId].sourceURL;
         const styleRuleUrl =
-            rule.match(/[:,\s]\s*url\s*\(\s*(?:'(\S*?)'|"(\S*?)"|((?:\\\s|\\\)|\\\"|\\\'|\S)*?))\s*\)/);
+            rule.match(/[:,\s]\s*url\s*\(\s*(?:'(\S*?)'|"(\S*?)"|((?:\\\s|\\\)|\\"|\\'|\S)*?))\s*\)/);
 
         if (styleRuleUrl && cssFileUrl) {
           const gr3 = styleRuleUrl[3];

--- a/src/usus.js
+++ b/src/usus.js
@@ -311,9 +311,9 @@ export const render = async (url: string, userConfiguration: UserConfigurationTy
           const gr3 = styleRuleUrl[3];
 
           if (gr3) {
-            const replace = URL.resolve(cssFileUrl, gr3);
+            const replace = URL.parse(URL.resolve(cssFileUrl, gr3));
 
-            rule = rule.replace(gr3, replace);
+            rule = rule.replace(gr3, replace.pathname);
           }
         }
 

--- a/test/usus.js
+++ b/test/usus.js
@@ -328,3 +328,33 @@ test('extracts only the used CSS', async (t) => {
 
   t.true(result.replace(/\s/g, '') === 'body{background:#f00;}');
 });
+
+test('rewrites relative paths in css', async (t) => {
+  const styleServer = await serve(`
+    body {
+      background-image: url(./images/image.jpg);
+    }
+  `, 'text/css');
+
+  const server = await serve(`
+    <html>
+      <head>
+        <link rel='stylesheet' href='${styleServer.url}'>
+      </head>
+      <body>
+        <p>Hello, World!</p>
+      </body>
+    </html>
+  `);
+
+  const result = await render(server.url, {
+    chromePort,
+    delay: 500,
+    extractStyles: true
+  });
+
+  await styleServer.close();
+  await server.close();
+
+  t.true(result.replace(/\s/g, '') === 'body{background-image:url(/images/image.jpg);}');
+});


### PR DESCRIPTION
Discussing [here](https://github.com/gajus/usus/issues/32)
I'm not an experienced js-developer but I think the code could be usefull to enspire you to release the most reliable fix on your own. 
It replaces relative paths with absolute ones based on css file location.
Thanks